### PR TITLE
Add index_information to mocked methods

### DIFF
--- a/mongomock_motor/__init__.py
+++ b/mongomock_motor/__init__.py
@@ -40,6 +40,7 @@ class AsyncMongoMockCollection():
         "create_index",
         "ensure_index",
         "map_reduce",
+        "index_information",
     ]
 
     def __init__(self, collection):


### PR DESCRIPTION
This mocked method is required by the beanie ODM. This PR by itself isn't enough to make this new mock fully compatible, we will also need to patch Beanie to support the runtime type checking of mocked objects.

https://github.com/roman-right/beanie/
https://github.com/roman-right/beanie/blob/2e104ee9602624b7c5e694e3f0a5f56a8a39d924/beanie/odm/settings/collection.py#L71