### PR TITLE
tz_aware option was not working (among other)

### DIFF
--- a/mongomock_motor/__init__.py
+++ b/mongomock_motor/__init__.py
@@ -146,7 +146,7 @@ class AsyncMongoMockDatabase():
 @masquerade_class('motor.motor_asyncio.AsyncIOMotorClient')
 class AsyncMongoMockClient():
     def __init__(self, *args, mock_build_info=None, **kwargs):
-        self.__client = MongoClient()
+        self.__client = MongoClient(*args, **kwargs)
         self.__databases = {}
         self.__build_info = mock_build_info
 


### PR DESCRIPTION
Hi, the thing is that `MongoClient` was not being initialized correctly. I discovered it while trying to use `tz_aware` parameter and queries always returned naive datetime instances.

I passed `*args` and `**kwargs` to the `MongoClient` initializer so all the MongoClient options can be used, but I haven't written tests for all options, just one for the tz_aware case, by the way.