### PR TITLE
BulkWriteResult couldn't be awaited

### DIFF
--- a/mongomock_motor/__init__.py
+++ b/mongomock_motor/__init__.py
@@ -73,6 +73,7 @@ class AsyncCursor():
 @masquerade_class('motor.motor_asyncio.AsyncIOMotorCollection')
 class AsyncMongoMockCollection():
     ASYNC_METHODS = [
+        'bulk_write',
         'count_documents',
         'count',
         'create_index',

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,6 +1,7 @@
 import bson
 import pytest
 from datetime import datetime, timezone
+from pymongo import ReplaceOne
 from mongomock_motor import AsyncMongoMockClient
 
 
@@ -51,3 +52,15 @@ async def test_tz_awareness():
     result = await collection.find_one()
     assert result["d"].tzinfo.__class__ is bson.tz_util.FixedOffset
 
+
+@pytest.mark.anyio
+async def test_bulk_write():
+    collection = AsyncMongoMockClient()['tests']['test']
+    result = await collection.bulk_write([
+        ReplaceOne(
+            filter={'_id': 1},
+            replacement={'_id': 1},
+            upsert=True
+        )
+    ])
+    assert result.bulk_api_result['nUpserted'] == 1


### PR DESCRIPTION
Using bulk_write returned this error
```
TypeError: object BulkWriteResult can't be used in 'await' expression
```
Now it's fixed