### PR TITLE
Add support for Mongo-Thingy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ flake8-quotes>=3.3.1,<4.0.0
 flake8>=4.0.1,<5.0.0
 pytest>=6.2.5,<7.0.0
 umongo>=3.1.0,<4.0.0
+Mongo-Thingy>=0.15.1,<1.0.0

--- a/tests/test_mongo_thingy.py
+++ b/tests/test_mongo_thingy.py
@@ -1,0 +1,31 @@
+from mongo_thingy import connect, AsyncThingy
+import pytest
+from mongomock_motor import AsyncMongoMockClient
+from pymongo.errors import DuplicateKeyError
+
+
+@pytest.mark.anyio
+async def test_mongo_thingy():
+    connect(client_cls=AsyncMongoMockClient)
+
+    class Something(AsyncThingy):
+        pass
+
+    Something.add_index('field1', unique=True)
+    await Something.create_indexes()
+
+    something1 = Something(field1='A', field2=':)', related=[])
+    await something1.save()
+
+    with pytest.raises(DuplicateKeyError, match="^E11000 Duplicate Key Error, full error: {'keyValue': {'field1': 'A'}, 'keyPattern': {'field1': 1}}$"):
+        duplicate = Something(field1='A', field2=':)', related=[])
+        await duplicate.save()
+
+    something2 = Something(field1='B', field2=';)', related=[something1.id])
+    await something2.save()
+
+    found = await Something.find_one({'field1': 'B'})
+    assert found
+    assert found.field1 == 'B'
+    assert found.field2 == ';)'
+    assert len(found.related) == 1


### PR DESCRIPTION
Hey there, thanks for the great library!

[Mongo-Thingy](https://github.com/Refty/mongo-thingy) is a sync + async ODM that already has Mongomock and Motor as supported backends, so I really would love to add mongomock-motor to the list. :)

This PR fixes the errors that are raised by our test suite when adding mongomock-motor to the list of tested backends ([see here](https://github.com/Refty/mongo-thingy/actions/runs/3680042764/jobs/6225185574) if you're curious).

Basically, we just handle a few more things that should be interesting in other situations too:
* `AsyncCursor.clone()` and `AsyncCursor.distinct()` that are missing;
* `AsyncMongoMockCollection.database` that doesn't return an `AsyncMongoMockDatabase` but the underlying class instead;
* as well as `AsyncMongoMockCollection.__eq__` and `AsyncMongoMockDatabase.__eq__` that are missing.

It also adds a test file for Mongo-Thingy, inspired by `test_umongo.py`, in case you want to keep the compatibility alive.