### PR TITLE
Fix patches when fields are enum members

### DIFF
--- a/mongomock_motor/patches.py
+++ b/mongomock_motor/patches.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from mongomock import DuplicateKeyError, helpers
 
 
@@ -61,6 +63,9 @@ def _normalize_strings(obj):
 
     if isinstance(obj, dict):
         return {_normalize_strings(k): _normalize_strings(v) for k, v in obj.items()}
+
+    if isinstance(obj, Enum):
+        return obj.value
 
     if isinstance(obj, str):
         return str(obj)

--- a/tests/test_mongo_thingy.py
+++ b/tests/test_mongo_thingy.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from mongo_thingy import connect, AsyncThingy
 import pytest
 from mongomock_motor import AsyncMongoMockClient
@@ -32,3 +33,20 @@ async def test_mongo_thingy():
     assert found.field1 == 'B'
     assert found.field2 == ';)'
     assert len(found.related) == 1
+
+
+@pytest.mark.anyio
+async def test_mongo_thingy_enums():
+    connect(client_cls=AsyncMongoMockClient)
+
+    class Importance(str, Enum):
+        HIGH = 'high'
+        LOW = 'low'
+
+    class Something(AsyncThingy):
+        pass
+
+    something1 = Something(importance='high')
+    await something1.save()
+
+    assert await Something.count({'importance': Importance.HIGH})

--- a/tests/test_umongo.py
+++ b/tests/test_umongo.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from marshmallow.exceptions import ValidationError
 from umongo import Document, fields
 from umongo.instance import Instance
@@ -40,3 +41,21 @@ async def test_umongo():
     assert first_related.field1 == 'A'
     assert first_related.field2 == ':)'
     assert first_related.related == []
+
+
+@pytest.mark.anyio
+async def test_umongo_enums():
+    instance = Instance.from_db(AsyncMongoMockClient()['tests'])
+
+    class Importance(str, Enum):
+        HIGH = 'high'
+        LOW = 'low'
+
+    @instance.register
+    class Something(Document):
+        importance = fields.StrField()
+
+    something1 = Something(importance='high')
+    await something1.commit()
+
+    assert await Something.count_documents({'importance': Importance.HIGH})


### PR DESCRIPTION
The current implementation of `_normalize_strings` transforms enum members into their representation, when it should give their value instead.

For example, with such an enum

```python
class Importance(str, Enum):
    HIGH = "high"
    LOW = "low"
```

a cursor like `Cursor({"importance": Importance.HIGH})` would see its filter transformed to `{"importance": "Importance.HIGH"}` instead of `{"importance": "high"}`, which will most likely not fetch anything.