### PR TITLE
feat: Add patch to provide error details for replace_one()

### DIFF
--- a/tests/test_mongo_thingy.py
+++ b/tests/test_mongo_thingy.py
@@ -30,6 +30,14 @@ async def test_mongo_thingy():
     something2 = Something(field1='B', field2=';)', related=[something1.id])
     await something2.save()
 
+    # DuplicateKeyError should be raised when replace
+    with pytest.raises(
+        DuplicateKeyError,
+        match="^E11000 Duplicate Key Error, full error: {'keyValue': {'field1': 'A'}, 'keyPattern': {'field1': 1}}$",
+    ):
+        something2.field1 = 'A'
+        await something2.save()
+
     found = await Something.find_one({'field1': 'B'})
     assert found
     assert found.field1 == 'B'

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -18,6 +18,21 @@ async def test_unique_while_inserting():
 
 
 @pytest.mark.anyio
+async def test_unique_while_replacing():
+    collection = AsyncMongoMockClient()['tests']['test']
+
+    await collection.create_index('a', unique=True)
+
+    await collection.insert_one({'a': 1})
+    result = await collection.insert_one({'a': 2})
+
+    with pytest.raises(DuplicateKeyError):
+        await collection.replace_one({'_id': result.inserted_id}, {'a': 1})
+
+    assert len(await collection.find({'a': 1}).to_list(None)) == 1
+
+
+@pytest.mark.anyio
 async def test_unique_while_creating_index():
     collection = AsyncMongoMockClient()['tests']['test']
 


### PR DESCRIPTION
Hi there, thanks for creating this fantastic package. It saves my life to test with `motor`.

In my use case, I also need the error details of `DuplicateKeyError` when using `replace_one()`. So I made this PR to fit my requirement. I think someone else might need this feature as well. Please let me know if the test cases or implementation should be modified. 👍 