### PR TITLE
add cursor.close stub

### DIFF
--- a/mongomock_motor/__init__.py
+++ b/mongomock_motor/__init__.py
@@ -118,6 +118,9 @@ class AsyncCursor:
     async def to_list(self, *args, **kwargs):
         return list(self.__cursor)
 
+    async def close(self):
+        pass
+
 
 @masquerade_class('motor.motor_asyncio.AsyncIOMotorLatentCommandCursor')
 class AsyncLatentCommandCursor:
@@ -140,6 +143,9 @@ class AsyncLatentCommandCursor:
 
     async def to_list(self, *args, **kwargs):
         return list(self.__cursor)
+
+    async def close(self):
+        pass
 
 
 @masquerade_class('motor.motor_asyncio.AsyncIOMotorCollection')

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,11 @@ import os
 import setuptools
 
 
-assert os.environ.get('GITHUB_REF_TYPE') == 'tag'
-assert os.environ.get('GITHUB_REF_NAME')
-VERSION = os.environ['GITHUB_REF_NAME'].lstrip('v')
+if os.environ.get('GITHUB_REF_TYPE') == 'tag':
+    assert os.environ.get('GITHUB_REF_NAME')
+    VERSION = os.environ['GITHUB_REF_NAME'].lstrip('v')
+else:
+    VERSION = "0.0.0-dev"
 
 
 with open("README.md", "r") as fh:

--- a/tests/test_async_cursor.py
+++ b/tests/test_async_cursor.py
@@ -79,6 +79,7 @@ async def test_next():
     # Check docs are correct
     assert docs == sample_docs
 
+    await cursor.close()
 
 @pytest.mark.anyio
 async def test_async_for():
@@ -108,6 +109,7 @@ async def test_async_for():
     # Check docs are correct
     assert docs == sample_docs
 
+    await cursor.close()
 
 @pytest.mark.anyio
 async def test_list_indexes():


### PR DESCRIPTION
currently when trying to close a cursor it leads to an exception: `TypeError: object NoneType can't be used in 'await' expression`

This just adds a stub function for `close`, so at least no exception is triggered