### PR TITLE
Add support close for cursors

### DIFF
--- a/mongomock_motor/__init__.py
+++ b/mongomock_motor/__init__.py
@@ -91,6 +91,12 @@ def with_cursor_chaining_methods(source, chaining_methods):
         'where',
     ],
 )
+@with_async_methods(
+    '__cursor',
+    [
+        'close',
+    ],
+)
 class AsyncCursor:
     def __init__(self, cursor):
         self.__cursor = cursor
@@ -176,6 +182,12 @@ class AsyncLatentCommandCursor:
         'save',
         'update_many',
         'update_one',
+    ],
+)
+@with_async_methods(
+    '__cursor',
+    [
+        'close',
     ],
 )
 class AsyncMongoMockCollection:

--- a/tests/test_async_cursor.py
+++ b/tests/test_async_cursor.py
@@ -7,6 +7,23 @@ EXPECTED_DOCUMENTS_COUNT = 10
 
 
 @pytest.mark.anyio
+async def test_closeable():
+    collection = AsyncMongoMockClient()['tests']['test']
+
+    # Insert sample documents into database
+    await collection.insert_many([{'i': i} for i in range(EXPECTED_DOCUMENTS_COUNT)])
+
+    # Create cursor
+    cursor = collection.find()
+
+    # Close cursor
+    await cursor.close()
+
+    # Closing of already closed cursor don't trigger errors
+    await cursor.close()
+
+
+@pytest.mark.anyio
 async def test_skip_and_limit():
     collection = AsyncMongoMockClient()['tests']['test']
 


### PR DESCRIPTION
Remake of PR #46 with separate test case, direct usage of cursor's `close` methods and without changes to `setup.py`.