### PR TITLE
fix: avoid patching collections multiple times; closes #49

### DIFF
--- a/mongomock_motor/__init__.py
+++ b/mongomock_motor/__init__.py
@@ -181,7 +181,7 @@ class AsyncLatentCommandCursor:
 class AsyncMongoMockCollection:
     def __init__(self, database, collection):
         self.database = database
-        self.__collection = collection
+        self.__collection = _patch_collection_internals(collection)
 
     def get_io_loop(self):
         return self.database.get_io_loop()
@@ -236,9 +236,7 @@ class AsyncMongoMockDatabase:
     def get_collection(self, *args, **kwargs):
         return AsyncMongoMockCollection(
             self,
-            _patch_collection_internals(
-                self.__database.get_collection(*args, **kwargs),
-            ),
+            self.__database.get_collection(*args, **kwargs),
         )
 
     def aggregate(self, *args, **kwargs) -> AsyncCursor:


### PR DESCRIPTION
- Avoid patching same collections multiple times.
- Add test for patching multiple collections.
- Refactor `_patch_iter_documents` a bit.
- Changed place where `_patch_collection_internals` is called. 