### PR TITLE
fix: make aggregate cursor closable

### DIFF
--- a/mongomock_motor/__init__.py
+++ b/mongomock_motor/__init__.py
@@ -126,6 +126,12 @@ class AsyncCursor:
 
 
 @masquerade_class('motor.motor_asyncio.AsyncIOMotorLatentCommandCursor')
+@with_async_methods(
+    '__cursor',
+    [
+        'close',
+    ],
+)
 class AsyncLatentCommandCursor:
     def __init__(self, cursor):
         self.__cursor = cursor
@@ -182,12 +188,6 @@ class AsyncLatentCommandCursor:
         'save',
         'update_many',
         'update_one',
-    ],
-)
-@with_async_methods(
-    '__cursor',
-    [
-        'close',
     ],
 )
 class AsyncMongoMockCollection:

--- a/tests/test_async_cursor.py
+++ b/tests/test_async_cursor.py
@@ -22,6 +22,15 @@ async def test_closeable():
     # Closing of already closed cursor don't trigger errors
     await cursor.close()
 
+    # Create command cursor
+    command_cursor = collection.aggregate([])
+
+    # Close cursor
+    await command_cursor.close()
+
+    # Closing of already closed cursor don't trigger errors
+    await command_cursor.close()
+
 
 @pytest.mark.anyio
 async def test_skip_and_limit():


### PR DESCRIPTION
a follow-up to https://github.com/michaelkryukov/mongomock_motor/pull/46 & https://github.com/michaelkryukov/mongomock_motor/pull/48. I think the `with_async_methods` method should've been added to the LatentCursor class, not to the Collection.